### PR TITLE
[BE-168]: Feat/remove redundnat functions

### DIFF
--- a/src/WeatherStationXM.sol
+++ b/src/WeatherStationXM.sol
@@ -65,26 +65,6 @@ contract WeatherStationXM is
     _burn(tokenId);
   }
 
-  function transferWeatherStation(address to, uint256 tokenId) external override returns (bool) {
-    if (!_isApprovedOrOwner(_msgSender(), tokenId)) {
-      revert CantTransferWSWhenNotOwning();
-    }
-    safeTransferFrom(_msgSender(), to, tokenId);
-    emit WeatherStationTransfered(_msgSender(), to, tokenId);
-    return true;
-  }
-
-  function exchangeWeatherStations(uint256 _tokenId1, uint256 _tokenId2) external override returns (bool) {
-    if (ownerOf(_tokenId1) != _msgSender() || ownerOf(_tokenId2) != _msgSender()) {
-      revert CantExchangeWSWhenNotOwning();
-    }
-    address from = ownerOf(_tokenId1);
-    address to = ownerOf(_tokenId2);
-    safeTransferFrom(from, to, _tokenId1);
-    safeTransferFrom(to, from, _tokenId2);
-    return true;
-  }
-
   function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
     super._pause();
   }
@@ -104,11 +84,11 @@ contract WeatherStationXM is
 
   // The following functions are overrides required by Solidity.
   function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
-    super._burn(tokenId);
+    ERC721URIStorage._burn(tokenId);
   }
 
   function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
-    return super.tokenURI(tokenId);
+    return ERC721URIStorage.tokenURI(tokenId);
   }
 
   function supportsInterface(

--- a/src/interfaces/IWeatherStationXM.sol
+++ b/src/interfaces/IWeatherStationXM.sol
@@ -38,10 +38,6 @@ interface IWeatherStationXM is IAccessControl, IERC721Enumerable {
 
   function burn(uint256 tokenId) external;
 
-  function transferWeatherStation(address to, uint256 tokenId) external returns (bool);
-
-  function exchangeWeatherStations(uint256 _tokenId1, uint256 _tokenId2) external returns (bool);
-
   //ops
   function pause() external;
 

--- a/test-foundry/WeatherStationXM.t.sol
+++ b/test-foundry/WeatherStationXM.t.sol
@@ -121,7 +121,7 @@ contract WeatherStationXMTest is Test {
         assertEq(weatherStationXM.totalSupply(), 1);
         vm.stopPrank();
         vm.startPrank(alice);
-        weatherStationXM.transferWeatherStation(bob, 1);
+        weatherStationXM.transferFrom(alice, bob, 1);
         vm.stopPrank();
     }
 
@@ -130,8 +130,8 @@ contract WeatherStationXMTest is Test {
         weatherStationXM.mintWeatherStation(alice, metadataURI);
         assertEq(weatherStationXM.balanceOf(alice), 1);
         assertEq(weatherStationXM.totalSupply(), 1);
-        vm.expectRevert(bytes4(keccak256("CantTransferWSWhenNotOwning()")));
-        weatherStationXM.transferWeatherStation(jack, 1);
+        vm.expectRevert("ERC721: caller is not token owner or approved");
+        weatherStationXM.transferFrom(bob, jack, 1);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
# Changes
- Removed `transferWeatherStation` as it duplicated the functionality of `safeTransferFrom`

# Fixes
- Removed `exchangeWeatherStations` because the approvals it required would allow one of the users to act maliciously and take the NFT without exchanging their own