### PR TITLE
[W3B-18]: chore: remove unused state vars from RewardPool

### DIFF
--- a/src/RewardPool.sol
+++ b/src/RewardPool.sol
@@ -38,15 +38,8 @@ contract RewardPool is
   mapping(uint256 => bytes32) public roots;
 
   uint256 public cycle;
-  uint256 private rewardsEnabled;
-  uint256 private companyEnabled;
-  uint256 public totalAllocatedRewards;
+  uint256 private lastRewardTs;
   uint256 public claimedRewards;
-  uint256 public companyWithdrawals;
-  address public companyTokensTarget;
-  address public businessDevTokensTarget;
-  uint256 public latestBusinessDevWithdrawal;
-  uint256 public latestCompanyWithdrawal;
 
   /* ========== ROLES ========== */
   bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
@@ -59,10 +52,10 @@ contract RewardPool is
    * @param period The period for which to enforce the rate limit
    * */
   modifier rateLimit(uint256 period) {
-    if (block.timestamp < rewardsEnabled) {
+    if (block.timestamp < lastRewardTs) {
       revert RewardsRateLimitingInEffect();
     }
-    rewardsEnabled = rewardsEnabled.add(period);
+    lastRewardTs = lastRewardTs.add(period);
     _;
   }
 
@@ -95,8 +88,7 @@ contract RewardPool is
     _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     _setupRole(UPGRADER_ROLE, _msgSender());
     token = IWeatherXM(_token);
-    rewardsEnabled = block.timestamp;
-    companyEnabled = block.timestamp;
+    lastRewardTs = block.timestamp;
   }
 
   /**

--- a/src/RewardPool.sol
+++ b/src/RewardPool.sol
@@ -88,7 +88,7 @@ contract RewardPool is
     _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     _setupRole(UPGRADER_ROLE, _msgSender());
     token = IWeatherXM(_token);
-    lastRewardTs = block.timestamp;
+    lastRewardRootTs = block.timestamp;
   }
 
   /**

--- a/src/RewardPool.sol
+++ b/src/RewardPool.sol
@@ -38,7 +38,7 @@ contract RewardPool is
   mapping(uint256 => bytes32) public roots;
 
   uint256 public cycle;
-  uint256 private lastRewardTs;
+  uint256 private lastRewardRootTs;
   uint256 public claimedRewards;
 
   /* ========== ROLES ========== */
@@ -52,10 +52,10 @@ contract RewardPool is
    * @param period The period for which to enforce the rate limit
    * */
   modifier rateLimit(uint256 period) {
-    if (block.timestamp < lastRewardTs) {
+    if (block.timestamp < lastRewardRootTs) {
       revert RewardsRateLimitingInEffect();
     }
-    lastRewardTs = lastRewardTs.add(period);
+    lastRewardRootTs = lastRewardRootTs.add(period);
     _;
   }
 


### PR DESCRIPTION
# Changes
- Removed some unused state variables from the `RewardPool` smart contract
- Renamed one variable to a more descriptive name