### PR TITLE
[W3B-2]: Chore/use enumerable to track next

### DIFF
--- a/src/WeatherStationXM.sol
+++ b/src/WeatherStationXM.sol
@@ -10,7 +10,6 @@ import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol"
 import { Pausable } from "@openzeppelin/contracts/security/Pausable.sol";
 import { IWeatherStationXM } from "./interfaces/IWeatherStationXM.sol";
 import { ERC721URIStorage } from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-import { Counters } from "@openzeppelin/contracts/utils/Counters.sol";
 
 contract WeatherStationXM is
   ERC721,
@@ -23,10 +22,6 @@ contract WeatherStationXM is
 {
   /* ========== LIBRARIES ========== */
   using SafeMath for uint256;
-  using Counters for Counters.Counter;
-
-  /* ========== STATE VARIABLES ========== */
-  Counters.Counter private _tokenIds;
 
   /**
    * @notice The PROVISIONER_ROLE is assigned to the BurnPool Contract.
@@ -50,8 +45,7 @@ contract WeatherStationXM is
     if (recipient == address(this)) {
       revert RecipientIsContractAddress();
     }
-    _tokenIds.increment();
-    uint256 newItemId = _tokenIds.current();
+    uint256 newItemId = totalSupply();
     super._safeMint(recipient, newItemId);
     super._setTokenURI(newItemId, uri);
     emit WeatherStationOnboarded(recipient, newItemId);

--- a/test-foundry/WeatherStationXM.t.sol
+++ b/test-foundry/WeatherStationXM.t.sol
@@ -77,7 +77,7 @@ contract WeatherStationXMTest is Test {
         assertEq(weatherStationXM.totalSupply(), 1);
         vm.stopPrank();
         vm.startPrank(alice);
-        weatherStationXM.burn(1);
+        weatherStationXM.burn(0);
         vm.stopPrank();
     }
 
@@ -92,7 +92,7 @@ contract WeatherStationXMTest is Test {
         vm.stopPrank();
         vm.startPrank(alice);
         vm.expectRevert(bytes("Pausable: paused"));
-        weatherStationXM.burn(1);
+        weatherStationXM.burn(0);
         vm.stopPrank();
     }
 
@@ -121,7 +121,8 @@ contract WeatherStationXMTest is Test {
         assertEq(weatherStationXM.totalSupply(), 1);
         vm.stopPrank();
         vm.startPrank(alice);
-        weatherStationXM.transferFrom(alice, bob, 1);
+        weatherStationXM.transferFrom(alice, bob, 0);
+        assertEq(weatherStationXM.ownerOf(0), bob);
         vm.stopPrank();
     }
 
@@ -131,7 +132,18 @@ contract WeatherStationXMTest is Test {
         assertEq(weatherStationXM.balanceOf(alice), 1);
         assertEq(weatherStationXM.totalSupply(), 1);
         vm.expectRevert("ERC721: caller is not token owner or approved");
-        weatherStationXM.transferFrom(bob, jack, 1);
+        weatherStationXM.transferFrom(bob, jack, 0);
+        assertEq(weatherStationXM.ownerOf(0), alice);
+        vm.stopPrank();
+    }
+
+    function testMintTheCorrectIds() public {
+        vm.startPrank(bob);
+        weatherStationXM.mintWeatherStation(alice, metadataURI);
+        assertEq(weatherStationXM.ownerOf(0), alice);
+
+        weatherStationXM.mintWeatherStation(bob, metadataURI);
+        assertEq(weatherStationXM.ownerOf(1), bob);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
# Changes
- Remove `tokenIds` state var from `WeatherStationXM` smart contract and keep track of ids using Enumerable's `totalSupply`
- Start `tokenIds` from 0. Previously were starting at 1.